### PR TITLE
Localized Moneris payment error messages

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -92,7 +92,7 @@ class Plugin extends BasePlugin
         Craft::$app->i18n->translations['moneris-gateway'] = [
             'class' => \yii\i18n\PhpMessageSource::class,
             'sourceLanguage' => 'en',
-            'basePath' => $this->getBasePath() . DIRECTORY_SEPARATOR . 'translations',
+            'basePath' => dirname($this->getBasePath()) . DIRECTORY_SEPARATOR . 'translations',
         ];
     }
 }

--- a/src/helpers/MonerisResponseMessage.php
+++ b/src/helpers/MonerisResponseMessage.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace allomambo\CommerceMoneris\helpers;
+
+use Craft;
+
+/**
+ * Maps Moneris ISO response codes to clean, localized user-facing messages.
+ *
+ * Per Moneris documentation: "Do NOT validate the combination of RBC and ISO
+ * response codes. These are liable to change without notice." — ISO codes are
+ * therefore the only reliable key used here.
+ */
+class MonerisResponseMessage
+{
+    /**
+     * Resolve a user-facing, localized message from the Moneris response fields.
+     *
+     * Priority:
+     *  1. ISO code match (always preferred — standardized and stable)
+     *  2. Generic decline fallback for response codes >= 050
+     *  3. Cleaned raw message (strip padding, asterisks, equals signs)
+     *  4. Generic fallback
+     */
+    public static function resolve(string $isoCode, string $responseCode, string $rawMessage): string
+    {
+        $isoCode = trim($isoCode);
+
+        // Step 1 — ISO code lookup
+        $message = self::messageForIso($isoCode);
+        if ($message !== null) {
+            return $message;
+        }
+
+        // Step 2 — generic decline for any unrecognised code >= 050
+        if ($responseCode !== '' && $responseCode !== 'null') {
+            $numericCode = (int)$responseCode;
+            if ($numericCode >= 50) {
+                return Craft::t('moneris-gateway', 'Your payment was declined. Please try a different card.');
+            }
+        }
+
+        // Step 3 — clean up the raw Moneris terminal message
+        $cleaned = self::cleanRawMessage($rawMessage);
+        if ($cleaned !== '') {
+            return $cleaned;
+        }
+
+        // Step 4 — final fallback
+        return Craft::t('moneris-gateway', 'Your payment could not be processed. Please try again.');
+    }
+
+    /**
+     * Map an ISO 8583 code to a localized user-facing message.
+     * Returns null when no specific mapping exists.
+     */
+    private static function messageForIso(string $iso): ?string
+    {
+        return match ($iso) {
+            // Refer to issuer
+            '01'      => Craft::t('moneris-gateway', 'Your payment was declined. Please contact your bank or try a different card.'),
+
+            // Do not honour / general decline
+            '05'      => Craft::t('moneris-gateway', 'Your payment was declined. Please try a different card.'),
+
+            // Invalid card number (Mod 10 / bad PAN / bad track)
+            '14', '15', '92' => Craft::t('moneris-gateway', 'The card number is invalid. Please check and try again.'),
+
+            // Re-enter / format / edit error
+            '06', '12', '13', '19', '20', '21', '25', '30' => Craft::t('moneris-gateway', 'An error occurred. Please try again.'),
+
+            // Restricted / lost / stolen card (avoid revealing sensitive status)
+            '36', '41', '43', '62' => Craft::t('moneris-gateway', 'Please use a different card.'),
+
+            // PIN tries exceeded
+            '38', '75' => Craft::t('moneris-gateway', 'Too many incorrect PIN attempts. Please contact your bank.'),
+
+            // No chequing account
+            '39', '52' => Craft::t('moneris-gateway', 'No chequing account found for this card.'),
+
+            // No savings account
+            '48', '53' => Craft::t('moneris-gateway', 'No savings account found for this card.'),
+
+            // Insufficient funds
+            '51'      => Craft::t('moneris-gateway', 'Insufficient funds. Please use a different card.'),
+
+            // Expired card
+            '54'      => Craft::t('moneris-gateway', 'This card has expired. Please use a different card.'),
+
+            // Incorrect PIN
+            '55'      => Craft::t('moneris-gateway', 'Incorrect PIN. Please try again.'),
+
+            // Card not set up for this transaction type
+            '56'      => Craft::t('moneris-gateway', 'This card is not set up for this type of transaction.'),
+
+            // Transaction not permitted to cardholder or terminal
+            '57', '58' => Craft::t('moneris-gateway', 'This transaction is not permitted for this card.'),
+
+            // Exceeds withdrawal amount or frequency limit
+            '61', '65' => Craft::t('moneris-gateway', 'This transaction exceeds your card limit.'),
+
+            // PIN / CVD security code error
+            '82'      => Craft::t('moneris-gateway', 'Security code error. Please check and try again.'),
+
+            // Card issuer temporarily unavailable
+            '91'      => Craft::t('moneris-gateway', 'Your bank is temporarily unavailable. Please try again later.'),
+
+            // System malfunction
+            '96'      => Craft::t('moneris-gateway', 'A system error occurred. Please try again later.'),
+
+            default   => null,
+        };
+    }
+
+    /**
+     * Strip padding, asterisks, equals signs, and excessive whitespace from the
+     * raw Moneris terminal message (e.g. "Re-Try             * Invalid Card #     =").
+     */
+    private static function cleanRawMessage(string $raw): string
+    {
+        // Remove asterisks, equals signs, and leading/trailing whitespace
+        $cleaned = trim(preg_replace('/[*=]+/', '', $raw) ?? '');
+
+        // Collapse multiple consecutive spaces into one
+        $cleaned = (string)preg_replace('/\s{2,}/', ' ', $cleaned);
+
+        return $cleaned;
+    }
+}

--- a/src/models/MonerisRequestResponse.php
+++ b/src/models/MonerisRequestResponse.php
@@ -131,7 +131,8 @@ class MonerisRequestResponse implements RequestResponseInterface
             return Craft::t('moneris-gateway', 'Invalid response from payment gateway');
         }
 
-        if (method_exists($this->response, 'getTimedOut') && $this->response->getTimedOut()) {
+        // getTimedOut() returns the string "true"/"false", not a boolean
+        if (method_exists($this->response, 'getTimedOut') && $this->response->getTimedOut() === 'true') {
             return Craft::t('moneris-gateway', 'Payment timed out. Please try again.');
         }
 

--- a/src/models/MonerisRequestResponse.php
+++ b/src/models/MonerisRequestResponse.php
@@ -2,8 +2,10 @@
 
 namespace allomambo\CommerceMoneris\models;
 
+use Craft;
 use craft\commerce\base\RequestResponseInterface;
 use craft\commerce\models\Transaction;
+use allomambo\CommerceMoneris\helpers\MonerisResponseMessage;
 
 /**
  * Moneris Request Response
@@ -126,37 +128,18 @@ class MonerisRequestResponse implements RequestResponseInterface
     public function getMessage(): string
     {
         if (!is_object($this->response)) {
-            return 'Invalid response from payment gateway';
+            return Craft::t('moneris-gateway', 'Invalid response from payment gateway');
         }
 
-        $message = '';
-        if (method_exists($this->response, 'getMessage')) {
-            $message = $this->response->getMessage() ?? '';
+        if (method_exists($this->response, 'getTimedOut') && $this->response->getTimedOut()) {
+            return Craft::t('moneris-gateway', 'Payment timed out. Please try again.');
         }
 
-        if (empty($message)) {
-            // Check for timeout
-            if (method_exists($this->response, 'getTimedOut') && $this->response->getTimedOut()) {
-                return 'Transaction timed out';
-            }
+        $iso  = method_exists($this->response, 'getISO') ? ((string)($this->response->getISO() ?? '')) : '';
+        $code = $this->getResponseCode();
+        $raw  = method_exists($this->response, 'getMessage') ? ((string)($this->response->getMessage() ?? '')) : '';
 
-            // Check for ISO code (error code)
-            if (method_exists($this->response, 'getISO')) {
-                $iso = $this->response->getISO() ?? '';
-                if (!empty($iso) && $iso !== 'null') {
-                    return 'ISO Error Code: ' . $iso;
-                }
-            }
-
-            $responseCode = $this->getResponseCode();
-            if (!empty($responseCode) && $responseCode !== 'null') {
-                return 'Response code: ' . $responseCode;
-            } else {
-                return 'Could not process transaction';
-            }
-        }
-
-        return (string)$message;
+        return MonerisResponseMessage::resolve($iso, $code, $raw);
     }
 
     /**

--- a/translations/en/moneris-gateway.php
+++ b/translations/en/moneris-gateway.php
@@ -19,5 +19,28 @@ return [
     'CVD' => 'CVD',
     'Store ID is required. Please enter a value or use an environment variable.' => 'Store ID is required. Please enter a value or use an environment variable.',
     'API Token is required. Please enter a value or use an environment variable.' => 'API Token is required. Please enter a value or use an environment variable.',
+
+    // Payment error messages
+    'Invalid response from payment gateway' => 'Invalid response from payment gateway',
+    'Payment timed out. Please try again.' => 'Payment timed out. Please try again.',
+    'Your payment was declined. Please contact your bank or try a different card.' => 'Your payment was declined. Please contact your bank or try a different card.',
+    'Your payment was declined. Please try a different card.' => 'Your payment was declined. Please try a different card.',
+    'The card number is invalid. Please check and try again.' => 'The card number is invalid. Please check and try again.',
+    'An error occurred. Please try again.' => 'An error occurred. Please try again.',
+    'Please use a different card.' => 'Please use a different card.',
+    'Too many incorrect PIN attempts. Please contact your bank.' => 'Too many incorrect PIN attempts. Please contact your bank.',
+    'No chequing account found for this card.' => 'No chequing account found for this card.',
+    'No savings account found for this card.' => 'No savings account found for this card.',
+    'Insufficient funds. Please use a different card.' => 'Insufficient funds. Please use a different card.',
+    'This card has expired. Please use a different card.' => 'This card has expired. Please use a different card.',
+    'Incorrect PIN. Please try again.' => 'Incorrect PIN. Please try again.',
+    'This card is not set up for this type of transaction.' => 'This card is not set up for this type of transaction.',
+    'This transaction is not permitted for this card.' => 'This transaction is not permitted for this card.',
+    'This transaction exceeds your card limit.' => 'This transaction exceeds your card limit.',
+    'Security code error. Please check and try again.' => 'Security code error. Please check and try again.',
+    'Your bank is temporarily unavailable. Please try again later.' => 'Your bank is temporarily unavailable. Please try again later.',
+    'A system error occurred. Please try again later.' => 'A system error occurred. Please try again later.',
+    'Your payment could not be processed. Please try again.' => 'Your payment could not be processed. Please try again.',
+    'The payment gateway did not respond. Please try again.' => 'The payment gateway did not respond. Please try again.',
 ];
 

--- a/translations/fr/moneris-gateway.php
+++ b/translations/fr/moneris-gateway.php
@@ -19,5 +19,28 @@ return [
     'CVD' => 'CVD',
     'Store ID is required. Please enter a value or use an environment variable.' => 'L\'ID du magasin est requis. Veuillez entrer une valeur ou utiliser une variable d\'environnement.',
     'API Token is required. Please enter a value or use an environment variable.' => 'Le jeton API est requis. Veuillez entrer une valeur ou utiliser une variable d\'environnement.',
+
+    // Messages d'erreur de paiement
+    'Invalid response from payment gateway' => 'Réponse invalide de la passerelle de paiement.',
+    'Payment timed out. Please try again.' => 'Le délai de paiement a expiré. Veuillez réessayer.',
+    'Your payment was declined. Please contact your bank or try a different card.' => 'Votre paiement a été refusé. Veuillez contacter votre banque ou utiliser une autre carte.',
+    'Your payment was declined. Please try a different card.' => 'Votre paiement a été refusé. Veuillez utiliser une autre carte.',
+    'The card number is invalid. Please check and try again.' => 'Le numéro de carte est invalide. Veuillez vérifier et réessayer.',
+    'An error occurred. Please try again.' => 'Une erreur est survenue. Veuillez réessayer.',
+    'Please use a different card.' => 'Veuillez utiliser une autre carte.',
+    'Too many incorrect PIN attempts. Please contact your bank.' => 'Trop de tentatives de NIP incorrectes. Veuillez contacter votre banque.',
+    'No chequing account found for this card.' => 'Aucun compte chèques trouvé pour cette carte.',
+    'No savings account found for this card.' => 'Aucun compte épargne trouvé pour cette carte.',
+    'Insufficient funds. Please use a different card.' => 'Fonds insuffisants. Veuillez utiliser une autre carte.',
+    'This card has expired. Please use a different card.' => 'Cette carte est expirée. Veuillez utiliser une autre carte.',
+    'Incorrect PIN. Please try again.' => 'NIP incorrect. Veuillez réessayer.',
+    'This card is not set up for this type of transaction.' => 'Cette carte n\'est pas configurée pour ce type de transaction.',
+    'This transaction is not permitted for this card.' => 'Cette transaction n\'est pas autorisée pour cette carte.',
+    'This transaction exceeds your card limit.' => 'Cette transaction dépasse la limite de votre carte.',
+    'Security code error. Please check and try again.' => 'Erreur de code de sécurité. Veuillez vérifier et réessayer.',
+    'Your bank is temporarily unavailable. Please try again later.' => 'Votre banque est temporairement indisponible. Veuillez réessayer plus tard.',
+    'A system error occurred. Please try again later.' => 'Une erreur système est survenue. Veuillez réessayer plus tard.',
+    'Your payment could not be processed. Please try again.' => 'Votre paiement n\'a pas pu être traité. Veuillez réessayer.',
+    'The payment gateway did not respond. Please try again.' => 'La passerelle de paiement n\'a pas répondu. Veuillez réessayer.',
 ];
 


### PR DESCRIPTION
## Summary

Improves payment error UX by replacing raw Moneris strings (e.g. `Re-Try * Invalid Card # =`) with clearer, **localized** messages for API consumers (#7).

## Changes

- **`MonerisResponseMessage`:** Central helper for mapping Moneris response codes/messages to user-facing strings.
- **`MonerisRequestResponse`:** Refactored message handling; treats `getTimedOut` as a string where applicable.
- **Translations:** Payment error strings added to gateway translations (EN + FR).
- **Plugin:** Translation base path updated for correct localization loading.

## Checklist

- [x] Enhancement: better error reporting (#7)
- [x] Manual testing completed

Fixes #7